### PR TITLE
Add Claudebin to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ We hope you find these prompts useful and have fun using Claude!
 ## Claude official prompt resource:
 * Claude Now has official [Prompt library](https://docs.anthropic.com/claude/prompt-library)
 * [Anthropic's Prompt Engineering Interactive Tutorial](https://github.com/anthropics/prompt-eng-interactive-tutorial)
+* [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - A minimalistic tool for publishing and sharing Claude coding sessions
 
 
 


### PR DESCRIPTION
Adding [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - a minimalistic tool for publishing and sharing Claude coding sessions.