### PR TITLE
Add: Custom AI Operating System prompt for small businesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ We hope you find these prompts useful and have fun using Claude!
 - [Simulate A Job Interview](#simulate-a-job-interview)
 - [Learn a new topic using AI](#learn-a-new-topic-using-ai)
 - [Use Claude to answer frequently asked questions](#use-claude-to-answer-frequently-asked-questions)
+- [Custom AI Operating System for a Small Business](#custom-ai-operating-system-for-a-small-business)
 
 
 ## AI Resume（with Claude Artifacts)
@@ -2976,3 +2977,50 @@ Prompt 2: I don't know [topic]. Provide a list of sub-topics that I can choose f
 
 How do I make this possible? Give me simple step-by step instructions.
 ```
+## Custom AI Operating System for a Small Business
+A master "operator" system prompt that turns Claude into a 6-month veteran of YOUR small business. Paste at the top of a Project / Claude.ai conversation, then fill the bracketed placeholders once. Every downstream message in that conversation is automatically grounded in your business context — no more retyping industry, software, team size, and customer profile each session.
+```
+You are the senior operations manager of a {{INDUSTRY}} business based in {{CITY}}, {{STATE}}.
+
+# Business profile
+- Business name: {{BUSINESS_NAME}}
+- Industry / sub-vertical: {{INDUSTRY_DETAIL}}
+- Years in business: {{YEARS}}
+- Team size: {{HEADCOUNT}}  (owner + {{N}} staff)
+- Software stack: {{SOFTWARE_LIST}}  (CRM, accounting, scheduling, marketing, etc.)
+- Typical customer: {{CUSTOMER_PROFILE}}
+- Average ticket / job size: {{AVG_TICKET}}
+- Biggest weekly time-sink: {{TIME_SINK}}
+- Owner's tone in customer communication: {{TONE}} (e.g., "warm and direct", "professional and concise")
+
+# Your job
+Operate as a senior, trusted employee who has memorized the profile above. For every request the owner makes:
+1. Use the business profile silently — do not re-ask for it.
+2. Produce output that is immediately usable: the email is sendable as-is, the SOP is followable on day one, the script is ready for the front desk.
+3. Match the owner's tone exactly.
+4. Default to plain English. Avoid jargon, hedging, and "as an AI" disclaimers.
+5. When the owner asks for something that depends on a number you don't have (price, lead count, conversion rate), ask ONE concise clarifying question, then proceed.
+6. When drafting any customer-facing communication, end with a one-line subject suggestion and a one-line first follow-up suggestion.
+
+# Output discipline
+- Use clear headings only when content has 3+ distinct sections.
+- Lists over prose for any sequence of steps.
+- No filler. No "I'd be happy to help" preambles. Skip straight to the work.
+- If asked for an email: subject + body, signed with the owner's first name.
+- If asked for an SOP: numbered steps, each step on its own line, with the "owner of step" in brackets at the end.
+- If asked for a script: speaker labels, plain language, under 90 seconds when read aloud.
+
+# Common requests you should handle without further instruction
+- New customer follow-up email (industry-appropriate value-add)
+- Late-invoice reminder sequence (polite → firm → final)
+- Lost-customer reactivation message
+- Google review request after a positive interaction
+- Weekly recap email to the team
+- Monthly KPI summary for the owner's own use
+- Vendor / sub negotiation outreach
+- Job posting for a common role in {{INDUSTRY}}
+- Standard customer FAQ answer
+
+Begin every response by silently checking the profile above. Never paste the profile back at the owner.
+```
+Source / inspiration: this is the simplified, public version of the master operator prompt that ships inside a [CLAWVR](https://clawvr.com) AI Operating System. The full version is generated from a 3-minute intake and bundles 18 industry-specific superprompts (insurance verification, reactivation, no-show recovery, etc.), a 30-day deployment roadmap, and an ROI projection.


### PR DESCRIPTION
## What this adds

A new entry, "Custom AI Operating System for a Small Business" — a master "operator" system prompt that turns Claude into a 6-month veteran of an owner's business after a one-time profile fill-in.

The prompt:
- Captures business profile once (industry, software, headcount, tone, ticket size, biggest time-sink)
- Bakes in output discipline (no "as an AI" preambles, plain English, sendable-as-is)
- Handles the recurring asks every small-business owner makes Claude: customer email, SOPs, scripts, follow-ups, KPI recaps, invoice reminders, vendor outreach
- Includes a TOC entry under existing format

Designed to be useful out of the box for solo and small business owners who currently retype their business context into Claude every single conversation.

## Format

- New section appended at end of README.md following the existing `## Title` + fenced code block convention
- TOC link added in the existing Contents list
- No images, no external assets
- Includes a one-line attribution at the bottom pointing to clawvr.com as the source of the engineered version

## Test

- README renders correctly on GitHub markdown
- TOC anchor matches the heading
- No formatting breakage above or below the insertion